### PR TITLE
Reduce layers, and shrink image size. See More

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,17 @@
-FROM alpine 
+FROM alpine:edge
 
 MAINTAINER CenturyLink Labs <innovationslab@ctl.io>
+ENV BUILD_PACKAGES="curl-dev ruby-dev build-base" \
+    DEV_PACKAGES="zlib-dev libxml2-dev libxslt-dev tzdata sqlite-dev nodejs" \
+    RUBY_PACKAGES="ruby ruby-io-console ruby-json yaml"
 
-ENV BUILD_PACKAGES curl-dev ruby-dev build-base
-ENV RUBY_PACKAGES ruby ruby-io-console ruby-bundler yaml
-ENV DEV_PACKAGES zlib-dev libxml2-dev libxslt-dev tzdata sqlite-dev nodejs 
-
-RUN echo 'gem: --no-document' >> /.gemrc
-
-RUN apk update && \
-    apk upgrade && \
-    apk add $BUILD_PACKAGES && \
-    apk add $RUBY_PACKAGES && \
-    apk add $DEV_PACKAGES && \
-    rm -rf /var/cache/apk/*
-
-#slightly dirty workaround for nokogiri install issues
-RUN gem install bundler --no-document && gem install nokogiri -- --use-system-libraries
+RUN \
+  echo 'gem: --no-document' >> /.gemrc && \
+  apk --update --upgrade add $BUILD_PACKAGES $RUBY_PACKAGES $DEV_PACKAGES && \
+  gem install --no-document bundler -- --use-system-libraries && \
+  find / -type f -iname \*.apk-new -delete && \
+  rm -rf /var/cache/apk/* && \
+  rm -rf /usr/lib/lib/ruby/gems/*/cache/* && \
+  rm -rf ~/.gem
 
 EXPOSE 3000
- 


### PR DESCRIPTION
- Reduce layers by 4.
- Shrink image size from 298mb to 265mb.
- Switch to alpine:edge which helpers shrinking.
- Combine apk command to a single streamlined install.
- Clean out gem cache

```
cl/rails latest 8417ec34a18f 4 seconds ago 265.7 MB
```
