### PR TITLE
Reduce layers, and shrink image size. See More

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
-FROM alpine:3.2 
+FROM alpine:3.2
 
 MAINTAINER CenturyLink Labs <innovationslab@ctl.io>
+ENV BUILD_PACKAGES="curl-dev ruby-dev build-base" \
+    DEV_PACKAGES="zlib-dev libxml2-dev libxslt-dev tzdata sqlite-dev yaml-dev" \
+    RUBY_PACKAGES="ruby ruby-io-console ruby-json yaml nodejs"
 
-ENV BUILD_PACKAGES curl-dev ruby-dev build-base
-ENV RUBY_PACKAGES ruby ruby-io-console ruby-bundler yaml
-ENV DEV_PACKAGES zlib-dev libgcrypt libxml2-dev libxslt-dev tzdata sqlite-dev nodejs 
+RUN \
+  apk --update --upgrade add $BUILD_PACKAGES $RUBY_PACKAGES $DEV_PACKAGES && \
+  gem install --no-document bundler && \
+  echo 'gem: --no-document' >> ~/.gemrc && \
+  cp ~/.gemrc /etc/gemrc && \
+  chmod uog+r /etc/gemrc && \
 
-RUN echo 'gem: --no-document' >> /.gemrc
-
-RUN apk --update --upgrade add $BUILD_PACKAGES $RUBY_PACKAGES $DEV_PACKAGES && \
-    rm -rf /var/cache/apk/*
-
-RUN gem install bundler --no-document 
+  bundle config --global build.nokogiri  "--use-system-libraries" && \
+  bundle config --global build.nokogumbo "--use-system-libraries" && \
+  find / -type f -iname \*.apk-new -delete && \
+  rm -rf /var/cache/apk/* && \
+  rm -rf /usr/lib/lib/ruby/gems/*/cache/* && \
+  rm -rf ~/.gem
 
 EXPOSE 3000
- 


### PR DESCRIPTION
- Reduce layers by 4.
- Shrink image size.
- Switch to alpine:3.2 which helpers shrinking.
- Combine apk command to a single streamlined install.
- Add bundle configurations for nokogiri and nokogumbo.
- Clean out gem cache
